### PR TITLE
added correct amount typing

### DIFF
--- a/src/main/java/org/gradoop/importer/finbench/functions/EdgeMapper.java
+++ b/src/main/java/org/gradoop/importer/finbench/functions/EdgeMapper.java
@@ -140,9 +140,9 @@ public class EdgeMapper implements Serializable {
      * @throws ParseException if an error occurs during converting DateTime to UNIX
      */
 
-    public TemporalEdge mapDeposit(Tuple2<Tuple2<Tuple4<String, String, String, String>, GradoopId>, GradoopId> data) throws ParseException {
+    public TemporalEdge mapDeposit(Tuple2<Tuple2<Tuple4<String, String, Double, String>, GradoopId>, GradoopId> data) throws ParseException {
 
-        Tuple4<String, String, String, String> edgeData = data.f0.f0;
+        Tuple4<String, String, Double, String> edgeData = data.f0.f0;
         GradoopId sourceId = data.f0.f1;
         GradoopId targetId = data.f1;
 
@@ -168,9 +168,9 @@ public class EdgeMapper implements Serializable {
      * @throws ParseException if an error occurs during converting DateTime to UNIX
      */
 
-    public TemporalEdge mapRepay(Tuple2<Tuple2<Tuple4<String, String, String, String>, GradoopId>, GradoopId> data) throws ParseException {
+    public TemporalEdge mapRepay(Tuple2<Tuple2<Tuple4<String, String, Double, String>, GradoopId>, GradoopId> data) throws ParseException {
 
-        Tuple4<String, String, String, String> edgeData = data.f0.f0;
+        Tuple4<String, String, Double, String> edgeData = data.f0.f0;
         GradoopId sourceId = data.f0.f1;
         GradoopId targetId = data.f1;
 
@@ -224,9 +224,9 @@ public class EdgeMapper implements Serializable {
      * @throws ParseException if an error occurs during converting DateTime to UNIX
      */
 
-    public TemporalEdge mapWithdraw(Tuple2<Tuple2<Tuple4<String, String, String, String>, GradoopId>, GradoopId> data) throws ParseException {
+    public TemporalEdge mapWithdraw(Tuple2<Tuple2<Tuple4<String, String, Double, String>, GradoopId>, GradoopId> data) throws ParseException {
 
-        Tuple4<String, String, String, String> edgeData = data.f0.f0;
+        Tuple4<String, String, Double, String> edgeData = data.f0.f0;
         GradoopId sourceId = data.f0.f1;
         GradoopId targetId = data.f1;
 

--- a/src/main/java/org/gradoop/importer/finbench/functions/EdgeReader.java
+++ b/src/main/java/org/gradoop/importer/finbench/functions/EdgeReader.java
@@ -163,12 +163,12 @@ public class EdgeReader implements Serializable {
      */
 
     public DataSet<TemporalEdge> readingDeposit(String filePath, DataSet<TemporalVertex> sourceVertices, DataSet<TemporalVertex> targetVertices){
-        DataSet<Tuple4<String, String, String, String>> csvEdgeData = env
+        DataSet<Tuple4<String, String, Double, String>> csvEdgeData = env
                 .readCsvFile(filePath)
                 .ignoreFirstLine()
                 .ignoreFirstLine()
                 .fieldDelimiter("|")
-                .types(String.class, String.class, String.class, String.class);
+                .types(String.class, String.class, Double.class, String.class);
 
         DataSet<Tuple2<String, GradoopId>> sourceIdPairs = generateIdPairs(sourceVertices);
         DataSet<Tuple2<String, GradoopId>> targetIdPairs = generateIdPairs(targetVertices);
@@ -178,12 +178,12 @@ public class EdgeReader implements Serializable {
                 .where(0)
                 .equalTo(0)
                 .with((entry, sourceIds) -> new Tuple2<>(entry, sourceIds.f1))
-                .returns(new TypeHint<Tuple2<Tuple4<String, String, String, String>, GradoopId>>() {})
+                .returns(new TypeHint<Tuple2<Tuple4<String, String, Double, String>, GradoopId>>() {})
                 .join(targetIdPairs)
                 .where("f0.f1")
                 .equalTo(0)
                 .with((joinedTuple, targetIds) -> new Tuple2<>(joinedTuple, targetIds.f1))
-                .returns(new TypeHint<Tuple2<Tuple2<Tuple4<String, String, String, String>, GradoopId>, GradoopId>>() {})
+                .returns(new TypeHint<Tuple2<Tuple2<Tuple4<String, String, Double, String>, GradoopId>, GradoopId>>() {})
                 .map(data -> edgeMapper.mapDeposit(data))
                 .returns(TypeInformation.of(new TypeHint<TemporalEdge>() {}));
     }
@@ -198,11 +198,11 @@ public class EdgeReader implements Serializable {
      */
 
     public DataSet<TemporalEdge> readingRepay(String filePath, DataSet<TemporalVertex> sourceVertices, DataSet<TemporalVertex> targetVertices) {
-        DataSet<Tuple4<String, String, String, String>> csvEdgeData = env
+        DataSet<Tuple4<String, String, Double, String>> csvEdgeData = env
                 .readCsvFile(filePath)
                 .ignoreFirstLine()
                 .fieldDelimiter("|")
-                .types(String.class, String.class, String.class, String.class);
+                .types(String.class, String.class, Double.class, String.class);
 
         DataSet<Tuple2<String, GradoopId>> sourceIdPairs = generateIdPairs(sourceVertices);
         DataSet<Tuple2<String, GradoopId>> targetIdPairs = generateIdPairs(targetVertices);
@@ -212,12 +212,12 @@ public class EdgeReader implements Serializable {
                 .where(0)
                 .equalTo(0)
                 .with((entry, sourceIds) -> new Tuple2<>(entry, sourceIds.f1))
-                .returns(new TypeHint<Tuple2<Tuple4<String, String, String, String>, GradoopId>>() {})
+                .returns(new TypeHint<Tuple2<Tuple4<String, String, Double, String>, GradoopId>>() {})
                 .join(targetIdPairs)
                 .where("f0.f1")
                 .equalTo(0)
                 .with((joinedTuple, targetIds) -> new Tuple2<>(joinedTuple, targetIds.f1))
-                .returns(new TypeHint<Tuple2<Tuple2<Tuple4<String, String, String, String>, GradoopId>, GradoopId>>() {})
+                .returns(new TypeHint<Tuple2<Tuple2<Tuple4<String, String, Double, String>, GradoopId>, GradoopId>>() {})
                 .map(data -> edgeMapper.mapRepay(data))
                 .returns(TypeInformation.of(new TypeHint<TemporalEdge>() {}));
     }
@@ -303,11 +303,11 @@ public class EdgeReader implements Serializable {
      */
 
     public DataSet<TemporalEdge> readingWithdraw(String filePath, DataSet<TemporalVertex> sourceVertices, DataSet<TemporalVertex> targetVertices) {
-        DataSet<Tuple4<String, String, String, String>> csvEdgeData = env
+        DataSet<Tuple4<String, String, Double, String>> csvEdgeData = env
                 .readCsvFile(filePath)
                 .ignoreFirstLine()
                 .fieldDelimiter("|")
-                .types(String.class, String.class, String.class, String.class);
+                .types(String.class, String.class, Double.class, String.class);
 
         DataSet<Tuple2<String, GradoopId>> sourceIdPairs = generateIdPairs(sourceVertices);
         DataSet<Tuple2<String, GradoopId>> targetIdPairs = generateIdPairs(targetVertices);
@@ -317,12 +317,12 @@ public class EdgeReader implements Serializable {
                 .where(0)
                 .equalTo(0)
                 .with((entry, sourceIds) -> new Tuple2<>(entry, sourceIds.f1))
-                .returns(new TypeHint<Tuple2<Tuple4<String, String, String, String>, GradoopId>>() {})
+                .returns(new TypeHint<Tuple2<Tuple4<String, String, Double, String>, GradoopId>>() {})
                 .join(targetIdPairs)
                 .where("f0.f1")
                 .equalTo(0)
                 .with((joinedTuple, targetIds) -> new Tuple2<>(joinedTuple, targetIds.f1))
-                .returns(new TypeHint<Tuple2<Tuple2<Tuple4<String, String, String, String>, GradoopId>, GradoopId>>() {})
+                .returns(new TypeHint<Tuple2<Tuple2<Tuple4<String, String, Double, String>, GradoopId>, GradoopId>>() {})
                 .map (data -> edgeMapper.mapWithdraw(data))
                 .returns(TypeInformation.of(new TypeHint<TemporalEdge>() {}));
         return edges;


### PR DESCRIPTION
The amount of money in deposit, repay and withdraw edges is now saved as a Double instead of a String.

This solves the issue of not being able to make queries such as amount > 100 on said edges.